### PR TITLE
Offering Fix for on_ready()

### DIFF
--- a/cogs/games.py
+++ b/cogs/games.py
@@ -11,10 +11,10 @@ class Games(commands.Cog):
 
     def __init__(self, client):
         self.client = client
+        self.client.loop.create_task(self.ready())
 
-    # Events
-    @commands.Cog.listener()
-    async def on_ready(self):
+    async def ready(self):
+        await self.client.wait_until_ready()
         print("Games Cog is ready")
 
     @commands.command(aliases=['8ball'])

--- a/cogs/level_system.py
+++ b/cogs/level_system.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 
 
 class Levels(commands.Cog):
-    def __init(self, client):
+    def __init__(self, client):
         self.client = client
         self.client.loop.create_task(self.ready())
 

--- a/cogs/level_system.py
+++ b/cogs/level_system.py
@@ -6,9 +6,10 @@ from discord.ext import commands
 class Levels(commands.Cog):
     def __init(self, client):
         self.client = client
+        self.client.loop.create_task(self.ready())
 
-    @commands.Cog.listener()
-    async def on_ready(self):
+    async def ready(self):
+        await self.client.wait_until_ready()
         print('Level system module is ready')
         # Needs to be implemented
 

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -10,9 +10,10 @@ players = {}
 class Music(commands.Cog):
     def __init__(self, client):
         self.client = client
+        self.client.loop.create_task(self.ready())
 
-    @commands.Cog.listener()
-    async def on_ready(self):
+    async def ready(self):
+        await self.client.wait_until_ready()
         print('Music module is ready')
 
     @commands.command()

--- a/cogs/toolkit.py
+++ b/cogs/toolkit.py
@@ -6,10 +6,10 @@ class Toolkit(commands.Cog):
     
     def __init__(self, client):
         self.client = client
+        self.client.loop.create_task(self.ready())
 
-    # Events
-    @commands.Cog.listener()
-    async def on_ready(self):
+    async def ready(self):
+        await self.client.wait_until_ready()
         print('Toolkit Cog is ready')
 
     # Commands

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -20,9 +20,8 @@ client = commands.Bot(command_prefix=PREFIX)
 status = cycle(['Nyanpasu!', 'Killin it'])
 
 
-# Event triggered when the bot has completed setup and is now ready to perform tasks
-@client.event
-async def on_ready():
+async def ready():
+    await client.wait_until_ready()
     await client.change_presence(status=discord.Status.online, activity=discord.Game('Nyanpasu!'))
     print(f'{client.user} has connected to Discord!')
     for guild in client.guilds:
@@ -71,5 +70,7 @@ async def unload(ctx, extension):
 for filename in os.listdir("./cogs"):
     if filename.endswith(".py"):
         client.load_extension(f'cogs.{filename[:-3]}')
+
+client.loop.create_task(ready())
 
 client.run(TOKEN)


### PR DESCRIPTION
# Fixed on_ready() Issues
Hey! I noticed you were doing some status changing `on_ready()`. I used to do this for my bot and it is unreliable, since `on_ready()` is not necessarily called once, and in some instances, doing anything `on_ready()` can disconnect your bot. I've modified it so that once your bot is ready, everything after `await client.wait_until_ready()` will execute. This way, nothing funky happens and you don't have to deal with the unreliability of `on_ready()`